### PR TITLE
fix: resolve mobile menu X button click issue

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,7 +114,7 @@ export default function Home() {
             <div className="md:hidden">
               <button
                 onClick={isMobileMenuOpen ? handleCloseButtonClick : toggleMobileMenu}
-                className="inline-flex items-center justify-center p-2 rounded-md text-slate-400 hover:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 touch-manipulation"
+                className="relative z-50 inline-flex items-center justify-center p-2 rounded-md text-slate-400 hover:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 touch-manipulation"
                 aria-expanded={isMobileMenuOpen}
                 aria-label={isMobileMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
               >
@@ -135,7 +135,7 @@ export default function Home() {
           {/* Mobile Menu */}
           <div 
             ref={menuRef}
-            className={`md:hidden transition-all duration-300 ease-in-out overflow-hidden ${
+            className={`md:hidden relative z-40 transition-all duration-300 ease-in-out overflow-hidden ${
               isMobileMenuOpen 
                 ? 'max-h-96 opacity-100' 
                 : 'max-h-0 opacity-0'


### PR DESCRIPTION
Fixes #7

Resolves mobile menu issue where X button doesn't close menu due to z-index layering problems.

## Changes
- Add `z-50` to mobile menu button for highest priority
- Add `z-40` to mobile menu div for lower priority
- Ensures X button remains clickable when menu is open on mobile

## Testing
The mobile menu X button should now properly close the menu on mobile devices.

Generated with [Claude Code](https://claude.ai/code)